### PR TITLE
service registration task

### DIFF
--- a/seed_control_interface_service/settings.py
+++ b/seed_control_interface_service/settings.py
@@ -175,6 +175,12 @@ CELERY_ROUTES = {
     'services.tasks.queue_poll_service': {
         'queue': 'priority',
     },
+    'services.tasks.service_metric_sync': {
+        'queue': 'mediumpriority',
+    },
+    'services.tasks.queue_service_metric_sync': {
+        'queue': 'mediumpriority',
+    },
     'services.tasks.get_user_token': {
         'queue': 'mediumpriority',
     },

--- a/seed_control_interface_service/settings.py
+++ b/seed_control_interface_service/settings.py
@@ -172,6 +172,9 @@ CELERY_ROUTES = {
     'services.tasks.poll_service': {
         'queue': 'priority',
     },
+    'services.tasks.queue_poll_service': {
+        'queue': 'priority',
+    },
     'services.tasks.get_user_token': {
         'queue': 'mediumpriority',
     },

--- a/services/tasks.py
+++ b/services/tasks.py
@@ -45,6 +45,19 @@ def deliver_hook_wrapper(target, payload, instance, hook):
     DeliverHook.apply_async(kwargs=kwargs)
 
 
+class QueuePollService(Task):
+    def run(self):
+        """
+        Queues all services to be polled. Should be run via beat.
+        """
+        services = Service.objects.all()
+        for service in services:
+            poll_service.apply_async(kwargs={"service_id": str(service.id)})
+        return "Queued <%s> Service(s) for Polling" % services.count()
+
+queue_poll_service = QueuePollService()
+
+
 class PollService(Task):
 
     """


### PR DESCRIPTION
When new seed services are registered on the system they need:
- [x] their metrics from their `/api/metrics` endpoint pulling into the dashboards/widgetdata model for usage
- [x] health check regularly checked
